### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,15 +8,15 @@
 .. image:: https://coveralls.io/repos/okfn/ckanext-esdstandards/badge.png?branch=master
   :target: https://coveralls.io/r/okfn/ckanext-esdstandards?branch=master
 
-.. image:: https://pypip.in/version/ckanext-esdstandards/badge.svg
+.. image:: https://img.shields.io/pypi/v/ckanext-esdstandards.svg
     :target: https://pypi.python.org/pypi/ckanext-esdstandards/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/ckanext-esdstandards/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/ckanext-esdstandards.svg
     :target: https://pypi.python.org/pypi/ckanext-esdstandards/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/license/ckanext-esdstandards/badge.svg
+.. image:: https://img.shields.io/pypi/l/ckanext-esdstandards.svg
     :target: https://pypi.python.org/pypi/ckanext-esdstandards/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ckanext-esdstandards))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ckanext-esdstandards`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.